### PR TITLE
Improve validation of the APK artifact in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,20 +199,52 @@ jobs:
       - name: Inspect APK package
         if: matrix.test == 'apk-inspect'
         run: |
+          echo "=== Current working directory ==="
+          pwd
+
+          echo "=== Available files in packages/ ==="
+          find packages/ -type f -name "*.apk" -exec ls -la {} \; 2>/dev/null || echo "No APK files found"
+
           APK_FILE=$(find packages/ -name "*.apk" | head -1)
           if [ -n "$APK_FILE" ]; then
             echo "=== APK Package Inspection ==="
-            echo "Package: $APK_FILE"
+            echo "Package (relative): $APK_FILE"
+
+            # Verify file exists before proceeding
+            if [ ! -f "$APK_FILE" ]; then
+              echo "ERROR: APK file not found at relative path: $APK_FILE"
+              exit 1
+            fi
+
             echo "Size: $(ls -lh "$APK_FILE" | awk '{print $5}')"
+
+            # Convert to absolute path before changing directories
+            APK_ABSOLUTE_PATH=$(readlink -f "$APK_FILE")
+            echo "Package (absolute): $APK_ABSOLUTE_PATH"
+
+            # Verify absolute path exists
+            if [ ! -f "$APK_ABSOLUTE_PATH" ]; then
+              echo "ERROR: APK file not found at absolute path: $APK_ABSOLUTE_PATH"
+              exit 1
+            fi
 
             mkdir -p /tmp/apk-extract
             cd /tmp/apk-extract
 
+            echo "=== Working directory after cd ==="
+            pwd
+
             echo "=== Extracting APK ==="
-            tar -xzf "$APK_FILE" 2>/dev/null || {
+            # Check if it's actually a tar.gz file
+            file "$APK_ABSOLUTE_PATH"
+
+            tar -xzf "$APK_ABSOLUTE_PATH" 2>/dev/null || {
               echo "Standard extraction had warnings, trying alternative..."
-              tar -xzf "$APK_FILE" 2>&1 | grep -v "APK-TOOLS.checksum" || true
+              tar -xzf "$APK_ABSOLUTE_PATH" 2>&1 | grep -v "APK-TOOLS.checksum" || true
             }
+
+            echo "=== Files after extraction ==="
+            ls -la
 
             echo "=== APK Structure ==="
             find . -type f | grep -E "(bin|lib|share)" | head -15
@@ -228,6 +260,10 @@ jobs:
               echo "--- .PKGINFO ---"
               head -10 .PKGINFO
             fi
+          else
+            echo "ERROR: No APK files found in packages/ directory"
+            echo "=== Contents of packages/ directory ==="
+            find packages/ -type f 2>/dev/null || echo "packages/ directory is empty or doesn't exist"
           fi
 
   release:

--- a/.gitignore
+++ b/.gitignore
@@ -1,36 +1,49 @@
-# Object files
-*.o
-*.obj
+# Build artifacts and packages
+packages/
+*.apk
+*.deb
+*.tar.gz
+*.changes
+*.rpm
+*.pkg
 
-# Generated Makefiles (keep the .src, .aux, .dcm, .inc templates)
-Makefile
-*/Makefile
-!Makefile.top
-!*/Makefile.*
+# Melange build files  
+melange.rsa
+melange.rsa.pub
 
-# Executables and binaries
-conquer
-conqrun
-conqsort
-cextract
-ezconv
+# Debian build artifacts
+debian/files
+debian/.debhelper/
+debian/conquerv5/
+debian/conquerv5.substvars
+debian/conquerv5.debhelper.log
 
-# Installation marker files
-in*
-**/in*
+# Temporary build directories
+build/
+dist/
+.build/
+**/build/
+**/dist/
 
-# Backup and temporary files
+# Editor files
 *~
+*.swp
+*.swo
+.*.swp
+.*.swo
 *.bak
-\#*
 *.tmp
 
-# Build artifacts
-sed.out
-
-# Documentation output
-*.doc
-
-# System specific
+# OS generated files  
 .DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
 Thumbs.db
+
+# IDE files
+.vscode/
+.idea/
+*.code-workspace

--- a/LICENSE-NOTICE.md
+++ b/LICENSE-NOTICE.md
@@ -1,18 +1,27 @@
 # Dual License Notice
 
-This repository contains two versions of Conquer v5.
-Conquer v5 is the evolution of Conquer v4. 
-The turn-based strategy game of Conquer, by Adam Bryant and Ed Barlow.  
-
-
-## Original Distribution (`original/` folder)
-- Contains the original version with restrictive licensing
-- Preserved for historical purposes
-- License: [Original restrictive license]
+This repository contains two versions of Conquer v5:
 
 ## GPL Release (`gpl-release/` folder)  
-- Relicensed under GPLv3 with author permissions
-- License: GNU General Public License v3.0
-- Permission granted by: 
-  Adam Bryant, 19/September/2025
-  Ed Barlow, 12/March/2016
+- **License:** GNU General Public License v3.0 or later (GPL-3.0-or-later)
+- **Status:** Relicensed with author permissions
+- **Distribution:** Freely redistributable and modifiable under GPL terms
+
+## Original Distribution (`original/` folder)
+- **License:** Original restrictive license (historical archive)
+- **Status:** Preserved for historical purposes only
+- **Distribution:** Restricted - see original license terms
+
+## Relicensing Permissions
+
+The original authors have granted explicit written permission to relicense under GPL:
+- **Adam Bryant:** September 19, 2025
+- **Ed Barlow:** March 12, 2016  
+- **Martin Forssen:** 2025
+
+**For packages and distributions:** Use the GPL-licensed version from `gpl-release/`
+
+**Copyright Holders:**
+- Ed Barlow and Adam Bryant (1987-1988, original authors)
+- Martin Forssen (1989, PostScript utilities)  
+- Juan Manuel Méndez Rey (2006-present, GPL relicensing and maintenance)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,52 @@ This repository contains **Conquer v5**, which includes:
 - **Purpose**: Modern open-source development
 - **Use**: Free to use, modify, and distribute under GPL terms
 
-**Legal Foundation**: Both original authors (Ed Barlow and Adam Bryant) have provided explicit written permission for GPL relicensing. See `RELICENSING-PERMISSIONS.md` for complete documentation.
+## GPL Relicensing History
+
+The transformation from restrictive to GPL licensing represents one of the most comprehensive retroactive relicensing efforts in gaming history, spanning nearly two decades (2006-2025).
+
+### Original Distribution Context
+
+Conquer was originally distributed via USENET newsgroups starting **October 26, 1987**, under restrictive terms that prohibited redistribution and modification. This was typical for software distributed in the pre-GPL era when "copyleft" licensing didn't exist.
+
+### Relicensing Timeline
+
+**2006-2011**: Initial contact and negotiations
+- Juan Manuel Méndez Rey (Vejeta) began tracking down original authors
+- Extensive internet searches to locate Ed Barlow and Adam Bryant
+- Initial discussions about open-source licensing
+
+**2011-2016**: Author permissions secured
+- **Adam Bryant (2011)**: *"Just wanted to confirm that I had no issues with publication of version 4 of Conquer under the GPL."*
+- **Ed Barlow (2016)**: *"Yes i delegated it all to adam aeons ago. Im easy on it all.... copyleft didnt exist when i wrote it and it was all for fun so..."*
+
+**2025**: Final contributor permissions
+- **Martin Forssen (2025)**: *"And I have no problem with relicensing it to GPL."* (PostScript utilities contributor)
+
+### Legal Foundation
+
+**Complete Documentation**: The full, unedited email correspondence containing explicit relicensing permissions from all copyright holders is preserved in [`gpl-release/RELICENSING-PERMISSIONS.md`](gpl-release/RELICENSING-PERMISSIONS.md) for legal compliance and transparency.
+
+This approach follows **Debian Legal guidelines** for proper open-source licensing:
+- Preserve complete written permissions from copyright holders
+- Maintain transparent legal framework for ongoing development
+- Document the entire relicensing process with verifiable evidence
+
+### Community Involvement
+
+The relicensing effort involved extensive community discussion:
+- **Debian Legal mailing lists**: Legal framework validation
+- **GNU Savannah**: Project hosting and GPL compliance
+- **USENET gaming community**: Historical context and source verification
+- **Academic institutions**: Historical preservation efforts
+
+### Technical Restoration
+
+Beyond legal licensing, the project involved significant technical work:
+- **Source code extraction**: Recovery from original USENET posts
+- **Build system modernization**: Cross-platform compilation support
+- **Code archaeology**: Understanding 1987-era Unix programming techniques
+- **Community contribution**: **quixadhal (Dread Quixadhal)** provided crucial assistance with source compilation
 
 ## Quick Start
 
@@ -92,7 +137,7 @@ The **original version** in the `original/` folder preserves the exact distribut
 - **Modern Documentation**: See `gpl-release/README.md` for current instructions
 - **Original Documentation**: See `original/README` for historical reference  
 - **Project History**: See `docs/HISTORY.md` for complete timeline
-- **Legal Framework**: See `RELICENSING-PERMISSIONS.md` for licensing details
+- **Legal Framework**: See `gpl-release/RELICENSING-PERMISSIONS.md` for licensing details
 
 ## Community and Support
 
@@ -121,23 +166,29 @@ Conquer represents one of the early multi-player computer strategy games, distri
 - **Developers** learning from classic game design
 - **Players** experiencing retro gaming
 - **Students** understanding Unix game programming techniques
+- **Legal scholars** studying retroactive open-source licensing
 
-## Legal Notes
+## The Relicensing Legacy
 
-This relicensing effort took place over 15+ years (2006-2025) and involved:
-- Tracking down original authors via internet searches
-- Obtaining explicit written permissions from all copyright holders
-- Following Debian Legal guidelines for proper documentation
-- Creating transparent legal framework for ongoing development
+This project demonstrates that even decades-old proprietary software can be successfully transitioned to open-source licensing through:
 
-The result is a legally sound GPL release while maintaining complete historical preservation.
+1. **Persistent effort**: Nearly 20 years of patient work
+2. **Legal diligence**: Proper documentation and community consultation
+3. **Technical preservation**: Maintaining both historical and modern versions
+4. **Community support**: Involving legal experts and gaming historians
+5. **Transparent process**: Complete documentation of permissions and procedures
+
+The result provides a **legally sound GPL release** while maintaining **complete historical preservation** - a model for other retroactive relicensing efforts.
 
 ## Acknowledgments
 
-- **Original Authors**: Ed Barlow and Adam Bryant
-- **GPL Coordinator**: Juan Manuel Méndez Rey (Vejeta)
-- **Community**: Debian Legal, GNU Savannah, USENET gaming community
-- **Additional Contributors**: See `AUTHORS.md` for complete list
+- **Original Authors**: Ed Barlow and Adam Bryant (1987-1988)
+- **PostScript Contributor**: Martin Forssen (1989)
+- **GPL Relicensing Coordinator**: Juan Manuel Méndez Rey (Vejeta) (2006-present)
+- **Technical Assistance**: quixadhal (Dread Quixadhal)
+- **Legal Guidance**: Debian Legal community
+- **Historical Preservation**: USENET gaming community, GNU Savannah
+- **Additional Contributors**: See `gpl-release/AUTHORS.md` for complete list
 
 ---
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -3,25 +3,9 @@ SPDX-PackageName = "conquerv5"
 SPDX-PackageSupplier = "Juan Manuel Méndez Rey <vejeta@gmail.com>"
 SPDX-PackageDownloadLocation = "https://github.com/vejeta/conquerv5"
 
-# Build artifacts - generated files with no meaningful copyright
-[[annotations]]
-path = [
-    "packages/alpine/x86_64/APKINDEX.tar.gz",
-    "packages/alpine/x86_64/conquerv5-5.0-r0.apk",
-    "packages/debian/conquerv5_5.0-1_arm64.changes",
-    "packages/debian/conquerv5_5.0-1_arm64.deb",
-    "packages/**/*.apk",
-    "packages/**/*.deb",
-    "packages/**/*.tar.gz",
-    "packages/**/*.changes"
-]
-precedence = "aggregate"
-SPDX-FileCopyrightText = "NONE"
-SPDX-License-Identifier = "NOASSERTION"
-
 # CI/CD and project infrastructure files
 [[annotations]]
-path = [".github/workflows/ci.yml", "gpl-release/.gitignore"]
+path = [".github/workflows/ci.yml", "gpl-release/.gitignore", ".reuseignore"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2025 Juan Manuel Méndez Rey <vejeta@gmail.com>"
 SPDX-License-Identifier = "GPL-3.0-or-later"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -3,26 +3,44 @@ SPDX-PackageName = "conquerv5"
 SPDX-PackageSupplier = "Juan Manuel Méndez Rey <vejeta@gmail.com>"
 SPDX-PackageDownloadLocation = "https://github.com/vejeta/conquerv5"
 
-# Martin Forssen contributed file - ntninfoG.c
+# Build artifacts - generated files with no meaningful copyright
 [[annotations]]
-path = "gpl-release/Src/ntninfoG.c"
-precedence = "aggregate"
-SPDX-FileCopyrightText = [
-    "1989 Martin Forssen <maf@recordedfuture.com>",
-    "1987-1992 Ed Barlow <barlowedward@hotmail.com>",
-    "1987-1992 Adam Bryant <adb@usa.com>", 
-    "2025 Juan Manuel Méndez Rey <vejeta@gmail.com>"
+path = [
+    "packages/alpine/x86_64/APKINDEX.tar.gz",
+    "packages/alpine/x86_64/conquerv5-5.0-r0.apk",
+    "packages/debian/conquerv5_5.0-1_arm64.changes",
+    "packages/debian/conquerv5_5.0-1_arm64.deb",
+    "packages/**/*.apk",
+    "packages/**/*.deb",
+    "packages/**/*.tar.gz",
+    "packages/**/*.changes"
 ]
-SPDX-License-Identifier = "GPL-3.0-or-later"
-SPDX-FileComment = "Originally written by Martin Forssen, later rewritten by Adam Bryant for new data structures"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "NONE"
+SPDX-License-Identifier = "NOASSERTION"
 
-# GPL-licensed source files in gpl-release/
+# CI/CD and project infrastructure files
+[[annotations]]
+path = [".github/workflows/ci.yml", "gpl-release/.gitignore"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2025 Juan Manuel Méndez Rey <vejeta@gmail.com>"
+SPDX-License-Identifier = "GPL-3.0-or-later"
+
+# Packaging and build scripts
+[[annotations]]
+path = ["packaging/**", "scripts/**"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2025 Juan Manuel Méndez Rey <vejeta@gmail.com>"
+SPDX-License-Identifier = "GPL-3.0-or-later"
+
+# GPL-licensed source files in gpl-release/ (relicensed with author permission)
 [[annotations]]
 path = ["gpl-release/Src/**", "gpl-release/Include/**", "gpl-release/Auxil/**"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = [
     "1987-1992 Ed Barlow <barlowedward@hotmail.com>",
-    "1987-1992 Adam Bryant <adb@usa.com>", 
+    "1987-1992 Adam Bryant <adb@usa.com>",
+    "1989 Martin Forssen <maf@recordedfuture.com>",
     "2025 Juan Manuel Méndez Rey <vejeta@gmail.com>"
 ]
 SPDX-License-Identifier = "GPL-3.0-or-later"
@@ -31,7 +49,11 @@ SPDX-License-Identifier = "GPL-3.0-or-later"
 [[annotations]]
 path = ["gpl-release/Docs/**", "gpl-release/*.md", "gpl-release/README", "gpl-release/CONVERTING", "gpl-release/PATCH28", "gpl-release/PROBLEMS", "gpl-release/HISTORY.md", "gpl-release/RELICENSING-PERMISSIONS.md", "gpl-release/CONTRIBUTORS.md"]
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2025 Juan Manuel Méndez Rey <vejeta@gmail.com>"
+SPDX-FileCopyrightText = [
+    "1987-1992 Ed Barlow <barlowedward@hotmail.com>",
+    "1987-1992 Adam Bryant <adb@usa.com>",
+    "2025 Juan Manuel Méndez Rey <vejeta@gmail.com>"
+]
 SPDX-License-Identifier = "GPL-3.0-or-later"
 
 # GPL-licensed build files in gpl-release/
@@ -41,7 +63,7 @@ precedence = "aggregate"
 SPDX-FileCopyrightText = "2025 Juan Manuel Méndez Rey <vejeta@gmail.com>"
 SPDX-License-Identifier = "GPL-3.0-or-later"
 
-# Original restrictive license source files
+# Original restrictive license source files (historical archive)
 [[annotations]]
 path = ["original/Src/**", "original/Include/**", "original/Auxil/**"]
 precedence = "aggregate"
@@ -51,7 +73,7 @@ SPDX-FileCopyrightText = [
 ]
 SPDX-License-Identifier = "LicenseRef-Original-Restrictive"
 
-# Original restrictive license documentation
+# Original restrictive license documentation (historical archive)
 [[annotations]]
 path = ["original/Docs/**", "original/README", "original/CONVERTING", "original/PATCH28", "original/PROBLEMS"]
 precedence = "aggregate"
@@ -61,7 +83,7 @@ SPDX-FileCopyrightText = [
 ]
 SPDX-License-Identifier = "LicenseRef-Original-Restrictive"
 
-# Original restrictive license build files
+# Original restrictive license build files (historical archive)
 [[annotations]]
 path = ["original/**/Makefile*"]
 precedence = "aggregate"

--- a/gpl-release/LICENSE.md
+++ b/gpl-release/LICENSE.md
@@ -1,63 +1,16 @@
 # LICENSE
 
-## Current License
+This software is licensed under the GNU General Public License v3.0 or later (GPL-3.0-or-later).
 
-This software is licensed under the **GNU General Public License v3.0 or later** (GPL-3.0-or-later).
+Copyright (C) 1987-1988 Ed Barlow and Adam Bryant
+Copyright (C) 1989 Martin Forssen - PostScript utilities
+Copyright (C) 2006-present Juan Manuel Méndez Rey - GPL relicensing and maintenance
 
-**Copyright (C) 1987-1988 Ed Barlow and Adam Bryant**  
-**Copyright (C) 1989 Martin Forssen (MaF) - PostScript utilities**   
-**Copyright (C) 2006-present Vejeta (GPL relicensing and maintenance)**  
-
-See the full text of the GPL-3.0 license in the file `GPL-3.0.txt` included with this distribution, or visit: https://www.gnu.org/licenses/gpl-3.0.html
-
-## Relicensing History
-
-**Original Distribution:** This game was originally distributed via USENET newsgroups starting October 26, 1987, under restrictive terms that prohibited redistribution and modification.
-
-**Relicensing:** The original authors have granted explicit written permission to relicense this work under the GNU General Public License.
-
-### Summary of Permissions Granted
-
-1. **Ed Barlow (2016):** *"Yes i delegated it all to adam aeons ago. Im easy on it all.... copyleft didnt exist when i wrote it and it was all for fun so..."* - Granted permission to relicense under GPL.
-
-2. **Adam Bryant (2011):** *"Just wanted to confirm that I had no issues with publication of version 4 of Conquer under the GPL."* - Confirmed permission to release under GPL.
-
-3. **Martin Forssen (MaF) (2025):** *"And I have no problem with relicensing it to GPL."* - Granted permission to relicense under GPL.
-
-### Legal Documentation
-
-**⚠️ COMPLETE EMAIL EVIDENCE:** The full, unedited email correspondence containing the explicit relicensing permissions from both original authors is preserved in [`RELICENSING-PERMISSIONS.md`](RELICENSING-PERMISSIONS.md) for legal compliance and transparency.
-
-This approach follows Debian Legal advice to preserve complete written permissions from copyright holders.
-
-## License Terms
+See the COPYING file for the full GPL-3.0 license text.
 
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
-
-## Additional Notes
-
-- Original USENET posts and historical references can be found in [`HISTORY.md`](HISTORY.md)
-- The relicensing process began in 2006 when Vejeta contacted the original authors
-- This relicensing effort was discussed on Debian Legal mailing lists and other forums
-- All source code extraction and compilation from original USENET posts was performed by the maintainer and **quixadhal (Dread Quixadhal)** - https://github.com/quixadhal
-- PostScript utilities by Martin Forssen were relicensed in 2025
-
-## Files in This Repository
-
-- `LICENSE` - This file (main license information)
-- `RELICENSING-PERMISSIONS.md` - Complete email correspondence (legal evidence)
-- `GPL-3.0.txt` - Full GPL-3.0 license text
-- `HISTORY.md` - Historical information about the game
-- `AUTHORS.md` - Credits and contributors
-
----
-
-**Repository Maintainer:** Juan Manuel Méndez Rey (Vejeta)
-**Relicensing Contact:** vejeta@gmail.com  
-**Last Updated:** 15th September 2025
-
-**For complete legal documentation:** See [`RELICENSING-PERMISSIONS.md`](RELICENSING-PERMISSIONS.md)
+Original authors have granted explicit permission to relicense under GPL-3.0-or-later.
+For complete relicensing documentation see RELICENSING-PERMISSIONS.md


### PR DESCRIPTION
While inspecting the actions that builds the artifacts.

https://github.com/vejeta/conquerv5/actions/

Notice that the APK was built, but the verification steps were failing.
This is to fix the APK validation step.


Additionally, there was some warnings about unrecognized licenses, so we perform a consolidation of the LICENSE files for better parsing of tools that check legal compliance.

